### PR TITLE
Updated accordion.tsx

### DIFF
--- a/packages/client/src/components/landingpage/data/accordion.tsx
+++ b/packages/client/src/components/landingpage/data/accordion.tsx
@@ -23,7 +23,7 @@ export const faq: Accordion[] = [
   {
     id: 3,
     question: 'On what chain will Haze Monkey mint on?',
-    answer: 'Etherium blockchain.'
+    answer: 'Ethereum blockchain.'
   },
   {
     id: 4,


### PR DESCRIPTION
Corrected spelling of Ethereum in the faq array, at "id: 3".  From "Etherium >>> Ethereum"